### PR TITLE
Remove Globe.engineer section from roadmap

### DIFF
--- a/study-roadmap.qmd
+++ b/study-roadmap.qmd
@@ -113,9 +113,7 @@ These are specific courses from Data Camp curated by Nicksy.
 - Hypothesis Testing in R (Advanced)
 - Exploratory Data Analysis in R (Advanced)
 
-### Globe.engineer
 
-- You can use [this](https://explorer.globe.engineer/) to generate your own custom study roadmap.
 
 ### Data Engineering 101
 


### PR DESCRIPTION
Removed Globe.engineer section and its link. Site says: Thank you for everything, but we were unable to be profitable, we are shutting down Sept 1. Services may be shaky until then, all subscriptions have been cancelled and will not renew.